### PR TITLE
Redspotnotes

### DIFF
--- a/Jupiter
+++ b/Jupiter
@@ -1,7 +1,7 @@
 The planets equatorial clouds take 18 hours to complete one rotation. The
 reason this happens is that Neptune does not have a solid body.
 
-The large red spot on the world is a hurricane raging for hundreds of years. 
+The large red spot on the world is a hurricane that has raged for at least hundreds of years. 
 
 Like Saturn, it also has rings. They are very faint, though.
 

--- a/Jupiter
+++ b/Jupiter
@@ -1,7 +1,7 @@
 The planets equatorial clouds take 18 hours to complete one rotation. The
 reason this happens is that Neptune does not have a solid body.
 
-The large red spot on the world is a hurricane raging for thousands of years. 
+The large red spot on the world is a hurricane raging for hundreds of years. 
 
 Like Saturn, it also has rings. They are very faint, though.
 


### PR DESCRIPTION
In addition to changing "thousands" to "hundreds," clarify that a note about Jupiter's red spot refers to the age of the storm rather than the lifespan. Fixes #4 